### PR TITLE
feat: automate external SKILL sync (external-skills.yaml + GitHub Action)

### DIFF
--- a/.github/workflows/update-external-skills.yml
+++ b/.github/workflows/update-external-skills.yml
@@ -1,0 +1,50 @@
+name: Update External Skills
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-skills:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup yq
+        uses: mikefarah/yq@v4.44.3
+
+      - name: Install configured external skills
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r repo skill; do
+            if [[ -z "${repo}" || -z "${skill}" ]]; then
+              continue
+            fi
+
+            echo "Installing skill '${skill}' from '${repo}'"
+            npx skills add "${repo}" --skill "${skill}"
+          done < <(yq eval -r '.skills[] | [.repo, .skill] | @tsv' external-skills.yaml)
+
+      - name: Create pull request if updates exist
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "chore: update external skills"
+          branch: chore/update-external-skills
+          commit-message: "chore: update external skills"
+          body: |
+            外部リポジトリで管理されている Skill を `external-skills.yaml` に基づいて自動更新しました。
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ AIコーディングアシスタント向けのスキル集です。
 ```bash
 npx skills add https://github.com/yoshinani-dev/skills
 ```
+
+## 外部 SKILL の取り込み
+
+外部リポジトリで管理されている SKILL は `external-skills.yaml` で管理します。
+
+```yaml
+skills:
+  - repo: https://github.com/anthropics/skills
+    skill: frontend-design
+```
+
+`.github/workflows/update-external-skills.yml` が毎週この一覧をもとに
+`npx skills add <repo> --skill <name>` を実行し、差分があれば自動で PR を作成します。

--- a/external-skills.yaml
+++ b/external-skills.yaml
@@ -1,0 +1,7 @@
+skills:
+  - repo: https://github.com/anthropics/skills
+    skill: frontend-design
+  - repo: https://github.com/vercel/turborepo
+    skill: turborepo
+  - repo: https://github.com/vercel/ai
+    skill: ai-sdk


### PR DESCRIPTION
### Motivation

- 外部リポジトリで管理されている SKILL を宣言的に管理し、`npx skills add <repo> --skill <name>` だけで導入できるようにしたい意図です。
- 外部 SKILL の差分や未インストール状態を定期的に検出して自動で取り込む運用を目指しています。

### Description

- 追加ファイル `external-skills.yaml` を導入し、外部 SKILL の `repo` と `skill` の組み合わせを宣言的に管理します.
- 新規ワークフロー `.github/workflows/update-external-skills.yml` を追加し、毎週（月曜）と手動実行で `external-skills.yaml` を読み取り `npx skills add "${repo}" --skill "${skill}"` を順次実行します.
- ワークフローは `yq` で YAML をパースし、差分があれば `peter-evans/create-pull-request` を使って自動で PR を作成します.
- `README.md` に外部 SKILL 取り込みの運用方法と `external-skills.yaml` の例を追記しました.

### Testing

- 実行したフォーマットチェックは `npx -y prettier --check README.md external-skills.yaml .github/workflows/update-external-skills.yml` で、初回はワークフローファイルのスタイル警告が出ましたが `npx -y prettier --write .github/workflows/update-external-skills.yml` を実行して最終的に `prettier --check` は成功しました. 
- リポジトリ状態は `git status --short` で確認し、変更を `git commit` して正常にコミットできることを確認しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a652850cb4832791f745f334b6541d)