### PR TITLE
feat(skills): freee会計スキルと郵便番号逆引きスクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,12 @@ npx skills add https://github.com/yoshinani-dev/skills
 必要なスキルのみをインストールする方法
 ```bash
 npx skills add https://github.com/yoshinani-dev/skills --skill submit-pr
+npx skills add https://github.com/yoshinani-dev/skills --skill freee-accounting
 ```
+
+## スキル一覧
+
+| スキル名 | 説明 |
+|----------|------|
+| submit-pr | PRの本文を作成・更新する |
+| freee-accounting | freee MCP で会計・見積書・請求書を操作する。取引先登録フロー、見積書作成フローを含む |

--- a/skills/freee-accounting/SKILL.md
+++ b/skills/freee-accounting/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: freee-accounting
+description: Uses freee MCP to access and manage freee accounting, invoicing, HR, and sales data. Triggers when the user mentions 営業利益, 売上, 損益, 取引, 請求書, 見積書, 経費, freee, 会計, 取引先, 試算表.
+---
+
+# freee 会計・経営 MCP
+
+## When to Use
+
+ユーザーが以下のような発言をしたとき、freee MCP を使用する:
+
+- **会計・集計**: 「営業利益」「売上」「損益」「試算表」「今期の業績」「freeeで〇〇を確認して」
+- **取引**: 「取引一覧」「取引を登録」「経費申請」
+- **請求**: 「請求書」「請求書一覧」「請求書を作成」「先月の請求書」
+- **見積**: 「見積書」「見積書一覧」「見積書を作成」「見積書を発行」
+- **マスタ**: 「取引先」「勘定科目」「部門」
+- **人事労務**: 従業員、勤怠、給与（freee 人事労務API対応時）
+- **汎用**: 「freee」「freee MCP」
+
+## 前提
+
+- 公式 freee MCP (`freee-mcp` npm パッケージ) が Cursor の mcp.json に設定されていること
+- ユーザーが `npx freee-mcp configure` で初回認証を完了していること
+- 請求書・見積書を使う場合は **[freee請求書] 見積書・請求書・納品書** の権限が必要
+
+---
+
+## 見積書作成の対話フロー（一問一答）
+
+見積書を新規作成するときは、**一問一答形式で順番に質問**し、回答を得てから次に進む。
+
+| 順 | 項目 | 質問例 | 備考 |
+|----|------|--------|------|
+| 1 | **取引先** | 「取引先はどちらですか？（社名や既存見積の取引先名でOK）」 | 既存見積一覧から partner_id を特定。不明なら候補を提示して選んでもらう |
+| 2 | **件名** | 「件名はどうしますか？」 | 例: 「〇〇制作のお見積り」「円陣」など |
+| 3 | **有効期限** | 「有効期限はいつにしますか？（YYYY-MM-DD、または「なし」）」 | 空の場合は null |
+| 4 | **明細** | 「要件・仕様・機能・工数を整理したファイルを共有してもらえますか？」 | ユーザーが提供したファイル（要件書・仕様書・工数表など）を読み込み、そこから明細（費目・工数・単価）を抽出 |
+| 5 | **枝番号**（任意） | 「枝番号を付けますか？（改訂版の場合など）」 | 通常は省略 |
+
+**取引先が存在しない場合**: **取引先を先に登録**してから見積書を作成する。詳細は「取引先が存在しない場合のフロー」を参照。
+
+**作成前の最終確認**: 見積書を **作成** する前には、入力内容の **最終確認** を必ず行う。
+
+---
+
+## 取引先登録に必要な情報
+
+| 項目 | 必須 | 説明 | 対話で聞くタイミング |
+|------|------|------|----------------------|
+| **取引先名（社名）** | ✓ | 正式名称 | 最初に必ず聞く |
+| **敬称** | △ | 御中で統一。聞かない | 固定で「御中」 |
+| **住所** | ✓ | 都道府県・市区町村・町域・番地など。郵便番号は住所から逆引き | 社名のあとに必ず聞く |
+| **インボイス番号（法人番号）** | ✓ | 適格請求書発行事業者の登録番号。法人は13桁、個人事業主は T+13桁 | 住所のあとに必ず聞く |
+
+---
+
+## 取引先が存在しない場合のフロー
+
+**チャット形式で1項目ずつ聞く**: **1問1答で順番に**情報を集める。
+
+| 順 | 質問例 | 回答例 |
+|----|--------|--------|
+| 1 | 会社名は？ | 株式会社テスト |
+| 2 | 住所は？（都道府県から番地まで） | 福岡県福岡市中央区天神4-7-6 |
+| 3 | インボイス番号（法人番号）は？ | 1234567890123 |
+
+※敬称は聞かず、御中で統一する。
+
+1. **確認**: 既存見積一覧（`/quotations`）と会計取引先（`/api/1/partners`）の両方で検索し、該当取引先がないことを確認する。
+2. **対話**: 「取引先が見つかりませんでした。新規登録してから見積書を作成します。」→ 上記の順で**1項目ずつ**質問し、回答を得てから次に進む。
+3. **郵便番号の逆引き**: 住所が得られたら `scripts/zipcode_from_address.py "<住所>"` を実行して郵便番号を取得。取得できない場合はユーザーに郵便番号を確認する。
+   - ※スクリプトは本スキルに同梱（`skills/freee-accounting/scripts/zipcode_from_address.py`）。プロジェクトの `scripts/` にコピーして使用する。
+4. **取引先登録（API）**: `freee_api_post` で会計APIの取引先を作成する。
+   - service: `"accounting"`
+   - path: `"/api/1/partners"`
+   - body 例: `{ "company_id": <company_id>, "name": "<取引先名>", "country_code": "JP", "default_title": "御中", "invoice_registration_number": "<インボイス番号>", "address_attributes": { "zipcode": "<逆引きで取得した7桁>", "prefecture_code": <1-47>, "street_name1": "<住所1>", "street_name2": "<住所2>" } }`
+   - ※`invoice_registration_number` が効かない場合は `long_name` を試す
+5. **partner_id 取得**: レスポンスの `partner.id` を `partner_id` として控える。
+6. **見積書作成を続行**: 件名以降の対話に進み、取得した `partner_id` で見積書を作成する。
+
+---
+
+## 見積書作成のAPI手順
+
+### Step 1: 事業所IDの確認
+
+```
+freee_get_current_company
+```
+
+### Step 2: テンプレートIDの取得
+
+```
+freee_api_get
+  service: "invoice"
+  path: "/quotations/templates"
+  query: { "company_id": <company_id> }
+```
+
+### Step 3: 取引先の特定
+
+既存見積書または会計取引先から `partner_id` を取得。未登録の場合は上記フローで先に登録。
+
+### Step 4: 見積書 body の組み立て
+
+```json
+{
+  "company_id": <company_id>,
+  "partner_id": <partner_id>,
+  "partner_title": "御中",
+  "subject": "〇〇開発のお見積り",
+  "quotation_date": "YYYY-MM-DD",
+  "expiration_date": "YYYY-MM-DD",
+  "template_id": <template_id>,
+  "tax_entry_method": "out",
+  "tax_fraction": "omit",
+  "withholding_tax_entry_method": "out",
+  "lines": [
+    {
+      "type": "item",
+      "description": "1. 開発費用",
+      "unit": "人日",
+      "quantity": 10,
+      "unit_price": "60000",
+      "tax_rate": 10
+    }
+  ]
+}
+```
+
+### Step 5: 見積書作成（POST）
+
+```
+freee_api_post
+  service: "invoice"
+  path: "/quotations"
+  body: <上記JSON>
+```
+
+**重要**: invoice サービスは `company_id` が自動付与されない。body に必ず `company_id` を含める。
+
+---
+
+## 利用可能なツール
+
+| ツール | 用途 |
+|-------|------|
+| `freee_get_current_company` | 現在の事業所 |
+| `freee_api_get` | データ取得 |
+| `freee_api_post` | 新規作成 |
+| `freee_api_put` | 更新 |
+
+### 主要 API パス
+
+| 用途 | service | パス |
+|------|---------|------|
+| 見積書 | invoice | `/quotations`, `/quotations/{id}` |
+| 見積書テンプレート | invoice | `/quotations/templates` |
+| 取引先 | accounting | `/api/1/partners` |
+| 損益計算書 | accounting | `/api/1/reports/trial_pl` |
+
+---
+
+## 参考
+
+- [freee MCP GitHub](https://github.com/freee/freee-mcp)
+- [freee API ドキュメント](https://developer.freee.co.jp/docs)

--- a/skills/freee-accounting/scripts/zipcode_from_address.py
+++ b/skills/freee-accounting/scripts/zipcode_from_address.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+住所から郵便番号を逆引きするスクリプト。
+
+日本郵便の郵便番号データ（UTF-8版）を使用。
+初回実行時にデータをダウンロードし、~/.cache/yoshinani/ にキャッシュする。
+
+Usage:
+  python zipcode_from_address.py "福岡県福岡市中央区天神4-7-6"
+  python zipcode_from_address.py "東京都千代田区丸の内1-1-1"
+"""
+import csv
+import re
+import sys
+import zipfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+# 日本郵便 UTF-8版 郵便番号データ
+ZIP_URL = "https://www.post.japanpost.jp/zipcode/dl/utf/zip/utf_ken_all.zip"
+CACHE_DIR = Path.home() / ".cache" / "yoshinani"
+CACHE_ZIP = CACHE_DIR / "utf_ken_all.zip"
+CACHE_CSV = CACHE_DIR / "utf_ken_all.csv"
+
+# 都道府県リスト（検索用）
+PREFECTURES = [
+    "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+    "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+    "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県",
+    "静岡県", "愛知県", "三重県", "滋賀県", "京都府", "大阪府", "兵庫県",
+    "奈良県", "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+    "徳島県", "香川県", "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県",
+    "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県",
+]
+
+
+def ensure_data() -> Path:
+    """郵便番号データをダウンロード・解凍してCSVパスを返す。"""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not CACHE_CSV.exists():
+        urlretrieve(ZIP_URL, CACHE_ZIP)
+        with zipfile.ZipFile(CACHE_ZIP, "r") as zf:
+            for name in zf.namelist():
+                if name.endswith(".csv"):
+                    zf.extract(name, CACHE_DIR)
+                    extracted = CACHE_DIR / name
+                    if extracted != CACHE_CSV:
+                        extracted.rename(CACHE_CSV)
+                    break
+
+    return CACHE_CSV
+
+
+def parse_address(addr: str) -> tuple[str | None, str | None, str | None]:
+    """
+    住所文字列から都道府県・市区町村・町域を抽出する。
+    例: "福岡県福岡市中央区天神4-7-6" -> ("福岡県", "福岡市中央区", "天神")
+    """
+    addr = addr.strip().replace(" ", "").replace("　", "")
+
+    # 都道府県を抽出
+    prefecture = None
+    rest = addr
+    for pref in PREFECTURES:
+        if addr.startswith(pref):
+            prefecture = pref
+            rest = addr[len(pref) :]
+            break
+
+    if not prefecture:
+        return None, None, None
+
+    # 番地（数字・ハイフン）の前までを市区町村・町域とする
+    match = re.match(r"^(.+?)(\d[\d\-－ー・]*)$", rest)
+    if match:
+        rest = match.group(1)
+
+    # 市区町村と町域を分割
+    city_match = re.match(r"^(.+?市.+?区)(.*)$", rest)
+    if city_match:
+        city = city_match.group(1)
+        town = city_match.group(2).strip()
+    else:
+        city_match = re.match(r"^(.+?(?:市|区|町|村|郡))(.*)$", rest)
+        if city_match:
+            city = city_match.group(1)
+            town = city_match.group(2).strip()
+        else:
+            city = rest
+            town = ""
+
+    if not town or town in ("以下に掲載がない場合", "その他"):
+        town = None
+    return prefecture, city, town if town else None
+
+
+def search_zipcode(csv_path: Path, prefecture: str, city: str, town: str | None) -> str | None:
+    """CSVから該当する郵便番号を検索する。"""
+    results = []
+    with open(csv_path, encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 9:
+                continue
+            zipcode = row[2].strip().strip('"')
+            pref_val = row[6].strip('"')
+            city_val = row[7].strip('"')
+            town_val = row[8].strip('"')
+
+            if pref_val != prefecture:
+                continue
+            if city not in city_val and city_val not in city:
+                continue
+            if town:
+                if town_val != "以下に掲載がない場合" and (town in town_val or town_val.startswith(town)):
+                    results.append((zipcode, town_val))
+            else:
+                results.append((zipcode, town_val))
+
+    if results:
+        results.sort(key=lambda x: (len(x[1]), x[0]))
+        return results[0][0]
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: zipcode_from_address.py <住所>", file=sys.stderr)
+        return 1
+
+    address = " ".join(sys.argv[1:])
+    if not address.strip():
+        print("", file=sys.stderr)
+        return 1
+
+    try:
+        csv_path = ensure_data()
+    except Exception as e:
+        print(f"データの取得に失敗しました: {e}", file=sys.stderr)
+        return 1
+
+    prefecture, city, town = parse_address(address)
+    if not prefecture:
+        print("", file=sys.stderr)
+        return 1
+
+    zipcode = search_zipcode(csv_path, prefecture, city, town)
+    if zipcode:
+        print(zipcode)
+        return 0
+    else:
+        print("", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 関連 Issue

（関連するIssueがあれば記載してください）

## 概要

freee会計・経営MCP向けのスキルを追加し、見積書作成や取引先登録の対話フローを詳細に記述しました。あわせて、住所から郵便番号を逆引きするスクリプトを追加しています。

### 変更内容

- **freee会計スキルの追加** (skills/freee-accounting/SKILL.md)
  - 見積書作成の一問一答フロー（取引先→件名→有効期限→明細→枝番号）
  - 取引先登録に必要な情報（社名・住所・インボイス番号）の定義
  - 取引先が存在しない場合のフロー（対話→郵便番号逆引き→API登録→見積書作成）
  - 見積書作成のAPI手順（事業所ID→テンプレート→取引先→body組み立て→POST）
  - 利用可能なツール・主要APIパスの参照
- **郵便番号逆引きスクリプトの追加** (skills/freee-accounting/scripts/zipcode_from_address.py)
  - 日本郵便のUTF-8郵便番号データを使用
  - 初回実行時にデータをダウンロードし、`~/.cache/yoshinani/` にキャッシュ
  - 住所（都道府県・市区町村・町域）から郵便番号を検索
- **READMEの更新**
  - インストール方法（全スキル・個別スキル）を追加
  - スキル一覧に freee-accounting を追加

## 動作確認方法

1. `skills/freee-accounting/scripts/zipcode_from_address.py` を実行し、住所から郵便番号が取得できることを確認
   - 例: `python zipcode_from_address.py "福岡県福岡市中央区天神4-7-6"`
2. freee MCP が設定済みの環境で、見積書作成や取引先登録のフローがスキルに従って動作することを確認
3. README のインストール手順が正しく表示されることを確認

## 伝達事項

- 郵便番号スクリプトは初回実行時に日本郵便のデータをダウンロードします（`~/.cache/yoshinani/` にキャッシュ）
- freee請求書の見積書・請求書機能利用には、freee MCP の設定と `[freee請求書] 見積書・請求書・納品書` 権限が必要です

## レビューに関して

レビューする際には、以下のprefix(接頭辞)を付けましょう。

| ラベル | 意味                            | 意図                                                               |
| ------ | ------------------------------- | ------------------------------------------------------------------ |
| q      | 質問 (Question)                 | 質問。相手は回答が必要                                             |
| fyi    | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用)    |
| nits   | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                               |
| nir    | お手すきで (No rush)            | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| imo    | 提案 (In my opinion)            | 個人的な見解や、軽微な提案。タスク化や修正を検討                   |
| must   | 必須 (Must)                     | これを直さないと承認できない。修正を検討                           |

Made with [Cursor](https://cursor.com)